### PR TITLE
Suggest legal cards including entered string

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,10 +21,12 @@ import {
 
 const Home: NextPage = (props) => {
   const [searchBox, setSearchBox] = useState('')
+  const [exactMatch, setExactMatch] = useState('')
   const [cardIsLegal, setCardIsLegal] = useState(false)
   const [suggestions, setSuggestions] = useState<string[]>([])
 
   const handleChange = (event: any) => {
+    setExactMatch('')
     const { value } = event.target
     const newSearchBox = value.trim().toLowerCase()
     setSearchBox(newSearchBox)
@@ -33,8 +35,17 @@ const Home: NextPage = (props) => {
   }
 
   const isLegal = (newSearchBox: string) => {
-    if (inObject(newSearchBox, legalCards.name)) return true
-    return inObject(newSearchBox, legalCards.name_ja)
+    const englishMatch = inObject(newSearchBox, legalCards.name)
+    if (englishMatch.length > 0) {
+      setExactMatch(englishMatch)
+      return true
+    }
+    const japaneseMatch = inObject(newSearchBox, legalCards.name_ja)
+    if (japaneseMatch.length > 0) {
+      setExactMatch(japaneseMatch)
+      return true
+    }
+    return false
   }
 
   const inObject = (needleTerm: string, hayObject: any) => {
@@ -46,16 +57,16 @@ const Home: NextPage = (props) => {
         continue
       }
       if (needleTerm == cardWeAreChecking.toLowerCase()) {
-        return true
+        return cardWeAreChecking
       }
     }
-    return false
+    return ''
   }
 
   const findOccurrences = (
     needleTerm: string,
     hayObject: any,
-    limit: number = 20
+    limit: number = 40
   ) => {
     let occurrences: string[] = []
     const keys = Object.keys(hayObject)
@@ -73,7 +84,7 @@ const Home: NextPage = (props) => {
     return occurrences
   }
 
-  const suggestCards = (searchTerm: string, limit: number = 20) => {
+  const suggestCards = (searchTerm: string, limit: number = 40) => {
     let occurences = findOccurrences(searchTerm, legalCards.name, limit)
     if (occurences.length > 0) return occurences
     return findOccurrences(searchTerm, legalCards.name_ja, limit)
@@ -100,7 +111,18 @@ const Home: NextPage = (props) => {
           />
           <InputRightElement>
             {cardIsLegal ? (
-              <CheckCircleIcon color="green.500" />
+              <>
+                <Link
+                  href={
+                    'https://scryfall.com/search?q=' +
+                    encodeURIComponent('prefer:oldest !"' + exactMatch + '"')
+                  }
+                  isExternal
+                >
+                  <CheckCircleIcon color="green.500" />
+                  <ExternalLinkIcon mx="2px" />
+                </Link>
+              </>
             ) : (
               <NotAllowedIcon color="red.500" />
             )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,19 +8,23 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Text
+  Text,
+  List,
+  ListItem
 } from '@chakra-ui/react'
 import { CheckCircleIcon, NotAllowedIcon } from '@chakra-ui/icons'
 
 const Home: NextPage = (props) => {
   const [searchBox, setSearchBox] = useState('')
   const [cardIsLegal, setCardIsLegal] = useState(false)
+  const [suggestions, setSuggestions] = useState<string[]>([])
 
   const handleChange = (event: any) => {
     const { value } = event.target
     const newSearchBox = value.trim().toLowerCase()
     setSearchBox(newSearchBox)
     if (typeof newSearchBox == 'string') setCardIsLegal(isLegal(newSearchBox))
+    setSuggestions(suggestCards(newSearchBox))
   }
 
   const isLegal = (newSearchBox: string) => {
@@ -43,6 +47,33 @@ const Home: NextPage = (props) => {
     return false
   }
 
+  const findOccurrences = (
+    needleTerm: string,
+    hayObject: any,
+    limit: number = 20
+  ) => {
+    let occurrences: string[] = []
+    const keys = Object.keys(hayObject)
+    for (let i = 0; i < keys.length; i++) {
+      const key: any = keys[i]
+      let cardWeAreChecking = hayObject[key]
+      if (cardWeAreChecking === null) {
+        continue
+      }
+      if (cardWeAreChecking.toLowerCase().indexOf(needleTerm) != -1) {
+        occurrences.push(cardWeAreChecking)
+        if (occurrences.length >= limit) break
+      }
+    }
+    return occurrences
+  }
+
+  const suggestCards = (searchTerm: string, limit: number = 20) => {
+    let occurences = findOccurrences(searchTerm, legalCards.name, limit)
+    if (occurences.length > 0) return occurences
+    return findOccurrences(searchTerm, legalCards.name_ja, limit)
+  }
+
   const legalCards = (props as cardsProps).legalCards
   const placeholderIndex = ~~(
     Math.random() * Object.keys(legalCards.name).length
@@ -55,7 +86,7 @@ const Home: NextPage = (props) => {
         <Heading as="h1" size="4xl">
           Middle School Deck Check
         </Heading>
-        <Text>Enter card name in English or Japanese</Text>
+        <Text mt="1em">Enter a card name in English or Japanese</Text>
         <InputGroup mt="2em">
           <Input
             name="searchBox"
@@ -63,9 +94,23 @@ const Home: NextPage = (props) => {
             onChange={handleChange}
           />
           <InputRightElement>
-            {cardIsLegal ? <CheckCircleIcon /> : <NotAllowedIcon />}
+            {cardIsLegal ? (
+              <CheckCircleIcon color="green.500" />
+            ) : (
+              <NotAllowedIcon color="red.500" />
+            )}
           </InputRightElement>
         </InputGroup>
+        <List spacing={3} mt="1em">
+          {suggestions.map((e) => {
+            return (
+              <ListItem key={e}>
+                <CheckCircleIcon color="green.500" /> &nbsp;
+                {e}
+              </ListItem>
+            )
+          })}
+        </List>
       </Container>
     </Box>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,9 +24,8 @@ const Home: NextPage = (props) => {
   }
 
   const isLegal = (newSearchBox: string) => {
-    let legal = inObject(newSearchBox, legalCards.name)
-    if (legal) return true
-    return inObject(newSearchBox, legalCards.name)
+    if (inObject(newSearchBox, legalCards.name)) return true
+    return inObject(newSearchBox, legalCards.name_ja)
   }
 
   const inObject = (needleTerm: string, hayObject: any) => {
@@ -34,7 +33,10 @@ const Home: NextPage = (props) => {
     for (let i = 0; i < keys.length; i++) {
       const key: any = keys[i]
       let cardWeAreChecking = hayObject[key]
-      if (needleTerm == cardWeAreChecking) {
+      if (cardWeAreChecking === null) {
+        continue
+      }
+      if (needleTerm == cardWeAreChecking.toLowerCase()) {
         return true
       }
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,9 +10,14 @@ import {
   InputRightElement,
   Text,
   List,
-  ListItem
+  ListItem,
+  Link
 } from '@chakra-ui/react'
-import { CheckCircleIcon, NotAllowedIcon } from '@chakra-ui/icons'
+import {
+  CheckCircleIcon,
+  NotAllowedIcon,
+  ExternalLinkIcon
+} from '@chakra-ui/icons'
 
 const Home: NextPage = (props) => {
   const [searchBox, setSearchBox] = useState('')
@@ -106,7 +111,15 @@ const Home: NextPage = (props) => {
             return (
               <ListItem key={e}>
                 <CheckCircleIcon color="green.500" /> &nbsp;
-                {e}
+                <Link
+                  href={
+                    'https://scryfall.com/search?q=' +
+                    encodeURIComponent('prefer:oldest !"' + e + '"')
+                  }
+                  isExternal
+                >
+                  {e} <ExternalLinkIcon mx="2px" />
+                </Link>
               </ListItem>
             )
           })}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,35 +18,27 @@ const Home: NextPage = (props) => {
 
   const handleChange = (event: any) => {
     const { value } = event.target
-    const newsearchBox = value.trim().toLowerCase()
-    setSearchBox(newsearchBox)
-    if (typeof newsearchBox == 'string') setCardIsLegal(isLegal(newsearchBox))
+    const newSearchBox = value.trim().toLowerCase()
+    setSearchBox(newSearchBox)
+    if (typeof newSearchBox == 'string') setCardIsLegal(isLegal(newSearchBox))
   }
 
-  const isLegal = (newsearchBox: string) => {
-    let keys = Object.keys(legalCards.name)
-    let legal = false
+  const isLegal = (newSearchBox: string) => {
+    let legal = inObject(newSearchBox, legalCards.name)
+    if (legal) return true
+    return inObject(newSearchBox, legalCards.name)
+  }
+
+  const inObject = (needleTerm: string, hayObject: any) => {
+    const keys = Object.keys(hayObject)
     for (let i = 0; i < keys.length; i++) {
       const key: any = keys[i]
-      let cardWeAreChecking = legalCards.name[key].toLowerCase()
-      if (newsearchBox == cardWeAreChecking) {
-        legal = true
-        break
+      let cardWeAreChecking = hayObject[key]
+      if (needleTerm == cardWeAreChecking) {
+        return true
       }
     }
-    if (legal) {
-      return true
-    }
-    keys = Object.keys(legalCards.name_ja)
-    for (let i = 0; i < keys.length; i++) {
-      const key: any = keys[i]
-      let cardWeAreChecking = legalCards.name_ja[key]
-      if (newsearchBox == cardWeAreChecking) {
-        legal = true
-        break
-      }
-    }
-    return legal
+    return false
   }
 
   const legalCards = (props as cardsProps).legalCards

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,23 +13,23 @@ import {
 import { CheckCircleIcon, NotAllowedIcon } from '@chakra-ui/icons'
 
 const Home: NextPage = (props) => {
-  const [cardName, setCardName] = useState('')
+  const [searchBox, setSearchBox] = useState('')
   const [cardIsLegal, setCardIsLegal] = useState(false)
 
   const handleChange = (event: any) => {
     const { value } = event.target
-    const newCardName = value.trim().toLowerCase()
-    setCardName(newCardName)
-    if (typeof newCardName == 'string') setCardIsLegal(isLegal(newCardName))
+    const newsearchBox = value.trim().toLowerCase()
+    setSearchBox(newsearchBox)
+    if (typeof newsearchBox == 'string') setCardIsLegal(isLegal(newsearchBox))
   }
 
-  const isLegal = (newCardName: string) => {
+  const isLegal = (newsearchBox: string) => {
     let keys = Object.keys(legalCards.name)
     let legal = false
     for (let i = 0; i < keys.length; i++) {
       const key: any = keys[i]
       let cardWeAreChecking = legalCards.name[key].toLowerCase()
-      if (newCardName == cardWeAreChecking) {
+      if (newsearchBox == cardWeAreChecking) {
         legal = true
         break
       }
@@ -41,7 +41,7 @@ const Home: NextPage = (props) => {
     for (let i = 0; i < keys.length; i++) {
       const key: any = keys[i]
       let cardWeAreChecking = legalCards.name_ja[key]
-      if (newCardName == cardWeAreChecking) {
+      if (newsearchBox == cardWeAreChecking) {
         legal = true
         break
       }
@@ -64,7 +64,7 @@ const Home: NextPage = (props) => {
         <Text>Enter card name in English or Japanese</Text>
         <InputGroup mt="2em">
           <Input
-            name="cardName"
+            name="searchBox"
             placeholder={placeholder}
             onChange={handleChange}
           />


### PR DESCRIPTION
Closes #4

- Rename cardName input to searchBox
- Bonus: refactor isLegal function
- Refectoring isLegal, continued
- Showing card names containing the entered string
- Suggestions now linked to Scryfall
- Linking exact matches from the check circle icon
